### PR TITLE
[SHOTS-632][iOS Event SDK] `DeviceId` updates upon every app launch

### DIFF
--- a/spresso-sdk-ios.podspec
+++ b/spresso-sdk-ios.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'spresso-sdk-ios'
-  s.version          = '1.2.1'
+  s.version          = '1.2.2'
   s.summary          = 'A short description of spresso-sdk-ios.'
 
 # This description is used to generate tags and improve search results.

--- a/spresso-sdk-ios/Classes/Spresso.m
+++ b/spresso-sdk-ios/Classes/Spresso.m
@@ -17,7 +17,7 @@
 #import "SPLogger.h"
 #import "SPKeychainItemWrapper.h"
 
-#define VERSION @"1.2.1"
+#define VERSION @"1.2.2"
 #define SPRESSO_FLUSH_INTERVAL 30
 
 
@@ -465,7 +465,7 @@ static Spresso *sharedInstance = nil;
 
 -(NSString*) getDeviceIdFromKeychain {
     
-    SPKeychainItemWrapper* wrapper = [[SPKeychainItemWrapper alloc] initWithIdentifier:@"SpressoDeviceID" accessGroup:@"Spresso"];
+    SPKeychainItemWrapper* wrapper = [[SPKeychainItemWrapper alloc] initWithIdentifier:@"SpressoDeviceID" accessGroup:nil];
     NSString* deviceId = [wrapper objectForKey:(__bridge id)(kSecValueData)];
     
     return deviceId;


### PR DESCRIPTION
**Descriptions**

- Fixed `DeviceId` updates upon every app launch caused by inconsistent `accessGroup` between storing to and querying from Keychain.

**Changes**

- Fixed `Spresso.getDeviceIdFromKeychain` to make `accessGroup` consistent with `storeDeviceIdInKeychain`.
- Bump SDK version to `1.2.2`

**JIRA**

- https://giddyinc.atlassian.net/browse/SHOTS-632